### PR TITLE
Better support for AWS credentials, support JSON config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ when the backup is complete, or when it fails.
 Example configuration
 ---------------------
 
-Configuration is in TOML format. The binary expects path to configuration file
-to be passed using the `--config` command line argument.
+Configuration can be either in JSON or TOML format. The binary expects path to
+configuration file to be passed using the `--config` command line argument.
+
+The followind example uses TOML:
 
 ```toml
 [backup_mysql_database]
@@ -43,7 +45,7 @@ command = ["tar", "-cvjf-", "/path/to/files"]
         bucket = "example-bucket"
         prefix = "my_tar_archive/daily/"
         suffix = "-my_tar_archive.tar.bz2"
-        [my_tar_archive.destination.s3.credentials]
+            [my_tar_archive.destination.s3.credentials]
             access_key_id = "AKIAIOSFODNN7EXAMPLE"
             secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ command = ["/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=
     type = "s3"
         [backup_mysql_database.destination.s3]
         region = "eu-west-1"
+        profile = "example-profile"
         bucket = "example-bucket"
         prefix = "my_database/daily/"
         suffix = "-my_database.sql.bz2"
@@ -42,4 +43,7 @@ command = ["tar", "-cvjf-", "/path/to/files"]
         bucket = "example-bucket"
         prefix = "my_tar_archive/daily/"
         suffix = "-my_tar_archive.tar.bz2"
+        [my_tar_archive.destination.s3.credentials]
+            access_key_id = "AKIAIOSFODNN7EXAMPLE"
+            secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 ```

--- a/config/destination.go
+++ b/config/destination.go
@@ -21,21 +21,23 @@ const (
 )
 
 type Destination struct {
-	Type DestinationType
-	S3   S3DestinationDefinition
+	Type DestinationType         `json:"type" toml:"type"`
+	S3   S3DestinationDefinition `json:"s3" toml:"s3"`
 }
 
 type S3DestinationDefinition struct {
-	Bucket      string
-	Prefix      string
-	Suffix      string
-	Region      string
-	Credentials *struct {
-		AccessKeyId     string
-		SecretAccessKey string
-		SessionToken    string
-	}
-	Profile *string
+	Bucket      string         `json:"bucket" toml:"bucket"`
+	Prefix      string         `json:"prefix" toml:"prefix"`
+	Suffix      string         `json:"suffix" toml:"suffix"`
+	Region      string         `json:"region" toml:"region"`
+	Credentials *S3Credentials `json:"credentials" toml:"credentials"`
+	Profile     *string        `json:"profile" toml:"profile"`
+}
+
+type S3Credentials struct {
+	AccessKeyId     string `json:"access_key_id" toml:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key" toml:"secret_access_key"`
+	SessionToken    string `json:"session_token,omitempty" toml:"session_token,omitempty"`
 }
 
 func (d S3DestinationDefinition) credentials() *credentials.Credentials {

--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
 	"testing"
 	"time"
 )
@@ -53,7 +54,7 @@ func TestClient(t *testing.T) {
 
 	t.Run("profile", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		tmpFile := tmpDir + "/credentials"
+		tmpFile := path.Join(tmpDir, "/credentials")
 		data := fmt.Sprintf("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n", testAwsProfile, testAwsAccessKeyId, testAwsSecretAccessKey)
 		if err := os.WriteFile(tmpFile, []byte(data), 0600); err != nil {
 			t.Fatal(err)
@@ -124,7 +125,7 @@ func TestClient(t *testing.T) {
 
 	t.Run("default_shared", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		tmpFile := tmpDir + "/credentials"
+		tmpFile := path.Join(tmpDir, "/credentials")
 		data := fmt.Sprintf("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n", testAwsProfile, testAwsAccessKeyId, testAwsSecretAccessKey)
 		if err := os.WriteFile(tmpFile, []byte(data), 0600); err != nil {
 			t.Fatal(err)

--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -1,22 +1,168 @@
 package config
 
 import (
+	"fmt"
+	"os"
 	"testing"
 	"time"
 )
 
-func TestClient(t *testing.T) {
-	t.Parallel()
+var (
+	testAwsProfile         = "streamlined-backup-test"
+	testAwsAccessKeyId     = "AKIAIOSFODNN7EXAMPLE"
+	testAwsSecretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	testAwsSessionToken    = "session-token"
+)
 
-	dest := &S3DestinationDefinition{
-		Bucket: "example-bucket",
-		Region: "eu-south-1",
-	}
-	if client := dest.Client(); client == nil {
-		t.Error("expected client to be created")
-	} else if *client.Config.Region != dest.Region {
-		t.Errorf("expected region %s, got %s", dest.Region, *client.Config.Region)
-	}
+func TestClient(t *testing.T) {
+	t.Run("static_credentials", func(t *testing.T) {
+		t.Parallel()
+
+		dest := &S3DestinationDefinition{
+			Bucket: "example-bucket",
+			Region: "eu-south-1",
+			Credentials: &struct {
+				AccessKeyId     string
+				SecretAccessKey string
+				SessionToken    string
+			}{
+				AccessKeyId:     testAwsAccessKeyId,
+				SecretAccessKey: testAwsSecretAccessKey,
+				SessionToken:    testAwsSessionToken,
+			},
+		}
+
+		client := dest.Client()
+		if client == nil {
+			t.Fatalf("expected client to be created")
+		}
+		if *client.Config.Region != dest.Region {
+			t.Errorf("expected region %s, got %s", dest.Region, *client.Config.Region)
+		}
+
+		credentials, err := client.Config.Credentials.Get()
+		if err != nil {
+			t.Fatalf("expected credentials to be set, got %s", err)
+		}
+		if credentials.AccessKeyID != testAwsAccessKeyId {
+			t.Errorf("expected access key id %s, got %s", testAwsAccessKeyId, credentials.AccessKeyID)
+		}
+		if credentials.SecretAccessKey != testAwsSecretAccessKey {
+			t.Errorf("expected secret access key %s, got %s", testAwsSecretAccessKey, credentials.SecretAccessKey)
+		}
+		if credentials.SessionToken != testAwsSessionToken {
+			t.Errorf("expected session token %s, got %s", testAwsSessionToken, credentials.SessionToken)
+		}
+	})
+
+	t.Run("profile", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := tmpDir + "/credentials"
+		data := fmt.Sprintf("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n", testAwsProfile, testAwsAccessKeyId, testAwsSecretAccessKey)
+		if err := os.WriteFile(tmpFile, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpFile)
+
+		dest := &S3DestinationDefinition{
+			Bucket:  "example-bucket",
+			Region:  "eu-west-1",
+			Profile: &testAwsProfile,
+		}
+
+		client := dest.Client()
+		if client == nil {
+			t.Fatalf("expected client to be created")
+		}
+		if *client.Config.Region != dest.Region {
+			t.Errorf("expected region %s, got %s", dest.Region, *client.Config.Region)
+		}
+
+		credentials, err := client.Config.Credentials.Get()
+		if err != nil {
+			t.Fatalf("expected credentials to be set, got %s", err)
+		}
+		if credentials.AccessKeyID != testAwsAccessKeyId {
+			t.Errorf("expected access key id %s, got %s", testAwsAccessKeyId, credentials.AccessKeyID)
+		}
+		if credentials.SecretAccessKey != testAwsSecretAccessKey {
+			t.Errorf("expected secret access key %s, got %s", testAwsSecretAccessKey, credentials.SecretAccessKey)
+		}
+		if credentials.SessionToken != "" {
+			t.Errorf("expected session token %s, got %s", "", credentials.SessionToken)
+		}
+	})
+
+	t.Run("default_env", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", testAwsAccessKeyId)
+		t.Setenv("AWS_SECRET_ACCESS_KEY", testAwsSecretAccessKey)
+		t.Setenv("AWS_SESSION_TOKEN", testAwsSessionToken)
+
+		dest := &S3DestinationDefinition{
+			Bucket: "example-bucket",
+			Region: "eu-south-1",
+		}
+
+		client := dest.Client()
+		if client == nil {
+			t.Fatalf("expected client to be created")
+		}
+		if *client.Config.Region != dest.Region {
+			t.Errorf("expected region %s, got %s", dest.Region, *client.Config.Region)
+		}
+
+		credentials, err := client.Config.Credentials.Get()
+		if err != nil {
+			t.Fatalf("expected credentials to be set, got %s", err)
+		}
+		if credentials.AccessKeyID != testAwsAccessKeyId {
+			t.Errorf("expected access key id %s, got %s", testAwsAccessKeyId, credentials.AccessKeyID)
+		}
+		if credentials.SecretAccessKey != testAwsSecretAccessKey {
+			t.Errorf("expected secret access key %s, got %s", testAwsSecretAccessKey, credentials.SecretAccessKey)
+		}
+		if credentials.SessionToken != testAwsSessionToken {
+			t.Errorf("expected session token %s, got %s", testAwsSessionToken, credentials.SessionToken)
+		}
+	})
+
+	t.Run("default_shared", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := tmpDir + "/credentials"
+		data := fmt.Sprintf("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n", testAwsProfile, testAwsAccessKeyId, testAwsSecretAccessKey)
+		if err := os.WriteFile(tmpFile, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpFile)
+		t.Setenv("AWS_PROFILE", testAwsProfile)
+
+		dest := &S3DestinationDefinition{
+			Bucket: "example-bucket",
+			Region: "eu-south-1",
+		}
+
+		client := dest.Client()
+		if client == nil {
+			t.Fatalf("expected client to be created")
+		}
+		if *client.Config.Region != dest.Region {
+			t.Errorf("expected region %s, got %s", dest.Region, *client.Config.Region)
+		}
+
+		credentials, err := client.Config.Credentials.Get()
+		if err != nil {
+			t.Fatalf("expected credentials to be set, got %s", err)
+		}
+		if credentials.AccessKeyID != testAwsAccessKeyId {
+			t.Errorf("expected access key id %s, got %s", testAwsAccessKeyId, credentials.AccessKeyID)
+		}
+		if credentials.SecretAccessKey != testAwsSecretAccessKey {
+			t.Errorf("expected secret access key %s, got %s", testAwsSecretAccessKey, credentials.SecretAccessKey)
+		}
+		if credentials.SessionToken != "" {
+			t.Errorf("expected session token %s, got %s", "", credentials.SessionToken)
+		}
+	})
 }
 
 func TestKey(t *testing.T) {

--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -21,11 +21,7 @@ func TestClient(t *testing.T) {
 		dest := &S3DestinationDefinition{
 			Bucket: "example-bucket",
 			Region: "eu-south-1",
-			Credentials: &struct {
-				AccessKeyId     string
-				SecretAccessKey string
-				SessionToken    string
-			}{
+			Credentials: &S3Credentials{
 				AccessKeyId:     testAwsAccessKeyId,
 				SecretAccessKey: testAwsSecretAccessKey,
 				SessionToken:    testAwsSessionToken,

--- a/config/main.go
+++ b/config/main.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Task struct {
-	Schedule    utils.ScheduleExpression
-	Command     []string
-	Cwd         string
-	Env         []string
-	Timeout     string
-	Destination Destination
+	Schedule    utils.ScheduleExpression `json:"schedule" toml:"schedule"`
+	Command     []string                 `json:"command" toml:"command"`
+	Cwd         string                   `json:"cwd" toml:"cwd"`
+	Env         []string                 `json:"env" toml:"env"`
+	Timeout     string                   `json:"timeout" toml:"timeout"`
+	Destination Destination              `json:"destination" toml:"destination"`
 }
 
 func LoadConfiguration(path string) (map[string]Task, error) {

--- a/config/main.go
+++ b/config/main.go
@@ -1,9 +1,16 @@
 package config
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+
 	"github.com/BurntSushi/toml"
 	"github.com/chialab/streamlined-backup/utils"
 )
+
+var ErrUnsupportedConfigFile = errors.New("unsupported config file")
 
 type Task struct {
 	Schedule    utils.ScheduleExpression `json:"schedule" toml:"schedule"`
@@ -16,9 +23,21 @@ type Task struct {
 
 func LoadConfiguration(path string) (map[string]Task, error) {
 	var config map[string]Task
-	if _, err := toml.DecodeFile(path, &config); err != nil {
-		return nil, err
+	switch {
+	case strings.HasSuffix(path, ".toml"):
+		if _, err := toml.DecodeFile(path, &config); err != nil {
+			return nil, err
+		}
+		return config, nil
+	case strings.HasSuffix(path, ".json"):
+		if data, err := os.ReadFile(path); err != nil {
+			return nil, err
+		} else if err := json.Unmarshal(data, &config); err != nil {
+			return nil, err
+		}
+
+		return config, nil
 	}
 
-	return config, nil
+	return nil, ErrUnsupportedConfigFile
 }

--- a/config/main_test.go
+++ b/config/main_test.go
@@ -1,0 +1,283 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/chialab/streamlined-backup/utils"
+)
+
+func TestLoadConfigurationToml(t *testing.T) {
+	t.Parallel()
+
+	data := `
+[backup_mysql_database]
+schedule = "30 4 * * *"
+command = ["/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=0 --set-gtid-purged=off my_database | bzip2"]
+    [backup_mysql_database.destination]
+    type = "s3"
+        [backup_mysql_database.destination.s3]
+        region = "eu-west-1"
+        profile = "streamlined-backup-test"
+        bucket = "example-bucket"
+        prefix = "my_database/daily/"
+        suffix = "-my_database.sql.bz2"
+
+[my_tar_archive]
+schedule = "30 4 * * *"
+command = ["tar", "-cvjf-", "/path/to/files"]
+    [my_tar_archive.destination]
+    type = "s3"
+        [my_tar_archive.destination.s3]
+        region = "eu-west-1"
+        bucket = "example-bucket"
+        prefix = "my_tar_archive/daily/"
+        suffix = "-my_tar_archive.tar.bz2"
+            [my_tar_archive.destination.s3.credentials]
+            access_key_id = "AKIAIOSFODNN7EXAMPLE"
+            secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+`
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(filePath, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	schedule, err := utils.NewSchedule("30 4 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]Task{
+		"backup_mysql_database": {
+			Schedule: *schedule,
+			Command:  []string{"/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=0 --set-gtid-purged=off my_database | bzip2"},
+			Destination: Destination{
+				Type: S3Destination,
+				S3: S3DestinationDefinition{
+					Region:  "eu-west-1",
+					Profile: &testAwsProfile,
+					Bucket:  "example-bucket",
+					Prefix:  "my_database/daily/",
+					Suffix:  "-my_database.sql.bz2",
+				},
+			},
+		},
+		"my_tar_archive": {
+			Schedule: *schedule,
+			Command:  []string{"tar", "-cvjf-", "/path/to/files"},
+			Destination: Destination{
+				Type: S3Destination,
+				S3: S3DestinationDefinition{
+					Region: "eu-west-1",
+					Credentials: &S3Credentials{
+						AccessKeyId:     "AKIAIOSFODNN7EXAMPLE",
+						SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+					},
+					Bucket: "example-bucket",
+					Prefix: "my_tar_archive/daily/",
+					Suffix: "-my_tar_archive.tar.bz2",
+				},
+			},
+		},
+	}
+
+	config, err := LoadConfiguration(filePath)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	for name, task := range config {
+		if task.Schedule.String() != expected[name].Schedule.String() {
+			t.Errorf("expected %s, got %s", expected[name].Schedule.String(), task.Schedule.String())
+		}
+		if !reflect.DeepEqual(task.Command, expected[name].Command) {
+			t.Errorf("expected %#v, got %#v", expected[name].Command, task.Command)
+		}
+		if !reflect.DeepEqual(task.Destination, expected[name].Destination) {
+			t.Errorf("expected %#v, got %#v", expected[name].Destination, task.Destination)
+		}
+		if !reflect.DeepEqual(task.Destination.S3.Credentials, expected[name].Destination.S3.Credentials) {
+			t.Errorf("expected %#v, got %#v", expected[name].Destination.S3.Credentials, task.Destination.S3.Credentials)
+		}
+	}
+}
+
+func TestLoadConfigurationTomlError(t *testing.T) {
+	t.Parallel()
+
+	data := `
+[backup_mysql_database]
+schedule = "30 4 * * *"
+schedule = "31 4 * * *" # Duplicate key
+`
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(filePath, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if config, err := LoadConfiguration(filePath); err == nil {
+		t.Errorf("expected error, got nil")
+	} else if config != nil {
+		t.Errorf("expected nil, got %#v", config)
+	} else if parseErr := new(toml.ParseError); !errors.As(err, parseErr) {
+		t.Errorf("expected %T, got %T", parseErr, err)
+	}
+}
+
+func TestLoadConfigurationJson(t *testing.T) {
+	t.Parallel()
+
+	data := `
+{
+"backup_mysql_database": {
+    "schedule": "30 4 * * *",
+    "command": ["/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=0 --set-gtid-purged=off my_database | bzip2"],
+    "destination": {
+        "type": "s3",
+        "s3": {
+            "region": "eu-west-1",
+            "profile": "streamlined-backup-test",
+            "bucket": "example-bucket",
+            "prefix": "my_database/daily/",
+            "suffix": "-my_database.sql.bz2"
+        }
+    }
+},
+"my_tar_archive": {
+    "schedule": "30 4 * * *",
+    "command": ["tar", "-cvjf-", "/path/to/files"],
+    "destination": {
+        "type": "s3",
+        "s3": {
+            "region": "eu-west-1",
+            "bucket": "example-bucket",
+            "prefix": "my_tar_archive/daily/",
+            "suffix": "-my_tar_archive.tar.bz2",
+            "credentials": {
+                "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	    }
+	}
+    }
+}
+}
+`
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "config.json")
+	if err := os.WriteFile(filePath, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	schedule, err := utils.NewSchedule("30 4 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]Task{
+		"backup_mysql_database": {
+			Schedule: *schedule,
+			Command:  []string{"/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=0 --set-gtid-purged=off my_database | bzip2"},
+			Destination: Destination{
+				Type: S3Destination,
+				S3: S3DestinationDefinition{
+					Region:  "eu-west-1",
+					Profile: &testAwsProfile,
+					Bucket:  "example-bucket",
+					Prefix:  "my_database/daily/",
+					Suffix:  "-my_database.sql.bz2",
+				},
+			},
+		},
+		"my_tar_archive": {
+			Schedule: *schedule,
+			Command:  []string{"tar", "-cvjf-", "/path/to/files"},
+			Destination: Destination{
+				Type: S3Destination,
+				S3: S3DestinationDefinition{
+					Region: "eu-west-1",
+					Credentials: &S3Credentials{
+						AccessKeyId:     "AKIAIOSFODNN7EXAMPLE",
+						SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+					},
+					Bucket: "example-bucket",
+					Prefix: "my_tar_archive/daily/",
+					Suffix: "-my_tar_archive.tar.bz2",
+				},
+			},
+		},
+	}
+
+	config, err := LoadConfiguration(filePath)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	for name, task := range config {
+		if task.Schedule.String() != expected[name].Schedule.String() {
+			t.Errorf("expected %s, got %s", expected[name].Schedule.String(), task.Schedule.String())
+		}
+		if !reflect.DeepEqual(task.Command, expected[name].Command) {
+			t.Errorf("expected %#v, got %#v", expected[name].Command, task.Command)
+		}
+		if !reflect.DeepEqual(task.Destination, expected[name].Destination) {
+			t.Errorf("expected %#v, got %#v", expected[name].Destination, task.Destination)
+		}
+		if !reflect.DeepEqual(task.Destination.S3.Credentials, expected[name].Destination.S3.Credentials) {
+			t.Errorf("expected %#v, got %#v", expected[name].Destination.S3.Credentials, task.Destination.S3.Credentials)
+		}
+	}
+}
+
+func TestLoadConfigurationJsonError(t *testing.T) {
+	t.Parallel()
+
+	data := `not a json`
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "config.json")
+	if err := os.WriteFile(filePath, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if config, err := LoadConfiguration(filePath); err == nil {
+		t.Errorf("expected error, got nil")
+	} else if config != nil {
+		t.Errorf("expected nil, got %#v", config)
+	} else if parseErr := new(json.SyntaxError); !errors.As(err, &parseErr) {
+		t.Errorf("expected %T, got %T", parseErr, err)
+	}
+}
+
+func TestLoadConfigurationJsonMissingFileError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "config.json")
+
+	if config, err := LoadConfiguration(filePath); err == nil {
+		t.Errorf("expected error, got nil")
+	} else if config != nil {
+		t.Errorf("expected nil, got %#v", config)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected %#v, got %#v", os.ErrNotExist, err)
+	}
+}
+
+func TestLoadConfigurationInvalidFormatError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "config.xml")
+
+	if config, err := LoadConfiguration(filePath); err == nil {
+		t.Errorf("expected error, got nil")
+	} else if config != nil {
+		t.Errorf("expected nil, got %#v", config)
+	} else if !errors.Is(err, ErrUnsupportedConfigFile) {
+		t.Errorf("expected %#v, got %#v", ErrUnsupportedConfigFile, err)
+	}
+}


### PR DESCRIPTION
This PR adds support for AWS credentials within this tool's configuration file.

To make this tool easier to configure with tools like Ansible, JSON config files are now supported.