### PR TITLE
Use PID file to avoid concurrent executions

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,8 @@ func (list *listOfStrings) String() string {
 func main() {
 	var slackWebhooks listOfStrings
 	flag.Var(&slackWebhooks, "slack-webhook", "Slack webhook URL (can be specified multiple times).")
-	cfgFilePath := flag.String("config", "", "Path to configuration file (TOML).")
+	cfgFilePath := flag.String("config", "", "Path to configuration file (TOML/JSON).")
+	pidFilePath := flag.String("pid", "/var/run/streamlined-backup.pid", "Path to PID file.")
 	parallel := flag.Uint("parallel", PARALLEL_TASKS, "Number of tasks to run in parallel.")
 	flag.Parse()
 
@@ -54,6 +55,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	pid := utils.NewPidFile(*pidFilePath)
+	if err := pid.Acquire(); err != nil {
+		panic(err)
+	}
+	defer pid.MustRelease()
 
 	now := time.Now()
 	results := tasks.Run(now, *parallel)

--- a/main.go
+++ b/main.go
@@ -57,7 +57,9 @@ func main() {
 	}
 
 	pid := utils.NewPidFile(*pidFilePath)
-	if err := pid.Acquire(); err != nil {
+	if err := pid.Acquire(); err == utils.ErrPidFileExists {
+		return
+	} else if err != nil {
 		panic(err)
 	}
 	defer pid.MustRelease()

--- a/utils/pid.go
+++ b/utils/pid.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"errors"
+	"log"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+var (
+	ErrPidFileNotFound = errors.New("pid file not found")
+	ErrPidFileStale    = errors.New("pid file exists but points to a not existing process")
+	ErrPidFileExists   = errors.New("pid file already exists and points to a valid process")
+)
+
+type PidFile struct {
+	path string
+}
+
+func NewPidFile(path string) *PidFile {
+	return &PidFile{path}
+}
+
+func (p *PidFile) current() (int, error) {
+	if data, err := os.ReadFile(p.path); err != nil {
+		return 0, ErrPidFileNotFound
+	} else if pid, err := strconv.Atoi(string(data)); err != nil {
+		return 0, ErrPidFileStale
+	} else if process, err := os.FindProcess(pid); err != nil {
+		return 0, ErrPidFileStale
+	} else if err := process.Signal(syscall.Signal(0)); err != nil {
+		return 0, ErrPidFileStale
+	} else {
+		return pid, nil
+	}
+}
+
+func (p *PidFile) Acquire() error {
+	if _, err := p.current(); err == nil {
+		return ErrPidFileExists
+	} else if err == ErrPidFileStale {
+		log.Default().Print("pid file exists but points to a not existing process")
+	}
+
+	if err := os.WriteFile(p.path, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *PidFile) Release() error {
+	if pid, err := p.current(); err != nil {
+		return err
+	} else if pid != os.Getpid() {
+		return ErrPidFileStale
+	} else if err := os.Remove(p.path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *PidFile) MustRelease() {
+	if err := p.Release(); err != nil {
+		panic(err)
+	}
+}

--- a/utils/pid_test.go
+++ b/utils/pid_test.go
@@ -1,0 +1,247 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"testing"
+)
+
+func TestPidAcquire(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
+
+	expected := strconv.Itoa(os.Getpid())
+	if data, err := os.ReadFile(pidFile); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if actual := string(data); actual != expected {
+		t.Errorf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestPidAcquireStale(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	} else if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0644); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	} else if err := cmd.Wait(); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("expected error, got none")
+	}
+
+	expected := strconv.Itoa(os.Getpid())
+	if data, err := os.ReadFile(pidFile); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if actual := string(data); actual != expected {
+		t.Errorf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestPidAcquireRunning(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	cmd := exec.Command("yes")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	expected := strconv.Itoa(cmd.Process.Pid)
+	if err := os.WriteFile(pidFile, []byte(expected), 0644); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	defer func() {
+		if err := cmd.Process.Signal(os.Kill); err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+		var exitErr *exec.ExitError
+		if err := cmd.Wait(); err != nil && !errors.As(err, &exitErr) {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	}()
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err == nil {
+		t.Errorf("expected error, got none")
+	} else if err != ErrPidFileExists {
+		t.Errorf("expected %#v, got %#v", ErrPidFileExists, err)
+	}
+
+	if data, err := os.ReadFile(pidFile); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if actual := string(data); actual != expected {
+		t.Errorf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestPidAcquireCorrupt(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+	if err := os.WriteFile(pidFile, []byte("corrupt"), 0644); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
+
+	expected := strconv.Itoa(os.Getpid())
+	if data, err := os.ReadFile(pidFile); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if actual := string(data); actual != expected {
+		t.Errorf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestPidRelease(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be created, got %#v", err)
+	}
+
+	if err := pid.Release(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if _, err := os.Stat(pidFile); err == nil || !os.IsNotExist(err) {
+		t.Errorf("expected file to be deleted, got %#v", err)
+	}
+}
+
+func TestPidReleaseCorrupt(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be created, got %#v", err)
+	}
+
+	if err := os.WriteFile(pidFile, []byte("corrupt"), 0644); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
+
+	if err := pid.Release(); err == nil || err != ErrPidFileStale {
+		t.Errorf("expected %#v, got %#v", ErrPidFileStale, err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be left untouched, got %#v", err)
+	}
+}
+
+func TestPidReleasePidChanged(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be created, got %#v", err)
+	}
+
+	cmd := exec.Command("yes")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0644); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	defer func() {
+		if err := cmd.Process.Signal(os.Kill); err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+		var exitErr *exec.ExitError
+		if err := cmd.Wait(); err != nil && !errors.As(err, &exitErr) {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	}()
+
+	if err := pid.Release(); err == nil || err != ErrPidFileStale {
+		t.Errorf("expected %#v, got %#v", ErrPidFileStale, err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be left untouched, got %#v", err)
+	}
+}
+
+func TestPidMustReleaseOk(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be created, got %#v", err)
+	}
+
+	pid.MustRelease()
+	if _, err := os.Stat(pidFile); err == nil || !os.IsNotExist(err) {
+		t.Errorf("expected file to be deleted, got %#v", err)
+	}
+}
+
+func TestPidMustReleaseError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := path.Join(tmpDir, "file.pid")
+
+	pid := NewPidFile(pidFile)
+	if err := pid.Acquire(); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	} else if _, err := os.Stat(pidFile); err != nil {
+		t.Errorf("expected file to be created, got %#v", err)
+	}
+
+	if err := os.WriteFile(pidFile, []byte("corrupt"), 0644); err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
+
+	defer func() {
+		if panicked := recover(); panicked == nil || panicked != ErrPidFileStale {
+			t.Errorf("expected %#v, got %#v", ErrPidFileStale, panicked)
+		} else if _, err := os.Stat(pidFile); err != nil {
+			t.Errorf("expected file to be left untouched, got %#v", err)
+		}
+	}()
+
+	pid.MustRelease()
+	t.Fatalf("expected panic")
+}


### PR DESCRIPTION
This PR adds PID file management to avoid running two instances of the same process at the same time.

This might happen, for example, if a cron job spawns a process every 5 minutes, but the backup tasks take 10 minutes to complete.