### PR TITLE
Multiple destinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 build:
 	@for GOOS in linux darwin; do \
 		for GOARCH in amd64 arm64; do \
-			go build -o build/stremlined-backup-$${GOOS}-$${GOARCH} -v main.go; \
+			go build -o build/streamlined-backup-$${GOOS}-$${GOARCH} -v main.go; \
 		done; \
 	done
 

--- a/backup/task_test.go
+++ b/backup/task_test.go
@@ -100,7 +100,7 @@ func TestNewTasks(t *testing.T) {
 	cfg := config.Task{
 		Command: []string{"echo", "foo bar"},
 		Env:     []string{"FOO=bar"},
-		Destination: []config.Destination{
+		Destinations: []config.Destination{
 			{Type: "s3"},
 		},
 	}
@@ -120,11 +120,6 @@ func TestNewTasks(t *testing.T) {
 	}
 	if len(task.destinations) != 1 {
 		t.Errorf("expected 1 destination, got %d", len(task.destinations))
-	}
-	for _, dest := range task.destinations {
-		if _, ok := dest.handler.(*handler.S3Handler); !ok {
-			t.Errorf("expected S3Handler, got %T", dest.handler)
-		}
 	}
 	if task.logger.Prefix() != "[foo] " {
 		t.Errorf("expected log prefix '[foo] ', got %s", task.logger.Prefix())
@@ -153,7 +148,7 @@ func TestNewTasksInvalidTimeout(t *testing.T) {
 		Command: []string{"echo", "bar foo"},
 		Env:     []string{"BAR=foo"},
 		Timeout: "foo bar",
-		Destination: []config.Destination{
+		Destinations: []config.Destination{
 			{Type: "s3"},
 		},
 	}
@@ -225,83 +220,6 @@ func TestTaskAccessors(t *testing.T) {
 	})
 }
 
-func TestShouldRun(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		expected bool
-		lastRun  time.Time
-		schedule string
-	}
-	cases := map[string]testCase{
-		"yes": {
-			expected: true,
-			lastRun:  time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local),
-			schedule: "0 10 * * *",
-		},
-		"no": {
-			expected: false,
-			lastRun:  time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local),
-			schedule: "@weekly",
-		},
-		"never_run": {
-			expected: true,
-			lastRun:  time.Time{},
-			schedule: "@weekly",
-		},
-	}
-	now := time.Date(2021, 10, 6, 19, 10, 38, 0, time.Local)
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			var (
-				schedule *utils.ScheduleExpression
-				err      error
-			)
-			if schedule, err = utils.NewSchedule(tc.schedule); err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
-			handler := &testHandler{lastRun: tc.lastRun}
-			task := &Task{
-				destinations: []destination{
-					{schedule: *schedule, handler: handler},
-				},
-			}
-
-			if result, err := task.shouldRun(now); err != nil {
-				t.Errorf("unexpected error: %s", err)
-			} else if result != tc.expected {
-				t.Errorf("expected %t, got %t", tc.expected, result)
-			}
-		})
-	}
-}
-
-func TestShouldRunError(t *testing.T) {
-	t.Parallel()
-
-	var (
-		schedule *utils.ScheduleExpression
-		err      error
-	)
-	if schedule, err = utils.NewSchedule("@daily"); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	testErr := errors.New("test error")
-	handler := &testHandler{lastRunErr: testErr}
-	task := &Task{
-		destinations: []destination{
-			{schedule: *schedule, handler: handler},
-		},
-	}
-
-	now := time.Date(2021, 10, 6, 19, 10, 38, 0, time.Local)
-	if result, err := task.shouldRun(now); result != false {
-		t.Errorf("unexpected result: %t", result)
-	} else if err != testErr {
-		t.Errorf("expected %v, got %v", testErr, err)
-	}
-}
-
 func TestRun(t *testing.T) {
 	t.Parallel()
 
@@ -312,16 +230,16 @@ func TestRun(t *testing.T) {
 		tmpDir = actualPath
 	}
 
-	handler := &testHandler{}
+	h := &testHandler{}
+	dest := handler.Destination{}
+	dest.SetHandler(h)
 	logger, lines := newTestLogger()
 	task := &Task{
-		command: []string{"bash", "-c", "echo $FOO; pwd; echo logging >&2"},
-		cwd:     tmpDir,
-		env:     []string{"FOO=barbaz"},
-		destinations: []destination{
-			{handler: handler},
-		},
-		logger: logger,
+		command:      []string{"bash", "-c", "echo $FOO; pwd; echo logging >&2"},
+		cwd:          tmpDir,
+		env:          []string{"FOO=barbaz"},
+		destinations: handler.Destinations{dest},
+		logger:       logger,
 	}
 	expectedData := fmt.Sprintf("barbaz\n%s\n", tmpDir)
 	expectedResultLogs := []string{"logging"}
@@ -331,11 +249,11 @@ func TestRun(t *testing.T) {
 	} else if !reflect.DeepEqual(res.Logs(), expectedResultLogs) {
 		t.Errorf("expected %q, got %q", expectedResultLogs, res.Logs())
 	}
-	if len(handler.chunks) != 1 {
-		t.Errorf("expected 1 chunk, got %d", len(handler.chunks))
+	if len(h.chunks) != 1 {
+		t.Errorf("expected 1 chunk, got %d", len(h.chunks))
 	}
 
-	if chunk := handler.chunks[0]; string(chunk) != expectedData {
+	if chunk := h.chunks[0]; string(chunk) != expectedData {
 		t.Errorf("expected %q, got %q", expectedData, chunk)
 	}
 
@@ -349,28 +267,28 @@ func TestRunLongOutput(t *testing.T) {
 	t.Parallel()
 
 	extraSize := testChunkSize / 2
-	handler := &testHandler{}
+	h := &testHandler{}
+	dest := handler.Destination{}
+	dest.SetHandler(h)
 	logger, lines := newTestLogger()
 	task := &Task{
-		command: []string{"bash", "-c", fmt.Sprintf("yes | head -c %d", testChunkSize+extraSize)},
-		destinations: []destination{
-			{handler: handler},
-		},
-		logger: logger,
+		command:      []string{"bash", "-c", fmt.Sprintf("yes | head -c %d", testChunkSize+extraSize)},
+		destinations: handler.Destinations{dest},
+		logger:       logger,
 	}
 
 	if res := task.Run(time.Now()); res.Status() != StatusSuccess {
 		t.Errorf("unexpected error: %+v", res)
 	}
-	if len(handler.chunks) != 2 {
-		t.Errorf("expected 2 chunks, got %d", len(handler.chunks))
+	if len(h.chunks) != 2 {
+		t.Errorf("expected 2 chunks, got %d", len(h.chunks))
 	}
 
-	if chunk := handler.chunks[0]; len(chunk) < testChunkSize {
+	if chunk := h.chunks[0]; len(chunk) < testChunkSize {
 		t.Errorf("expected at least %d bytes, got %d", testChunkSize, len(chunk))
 	}
 
-	if chunk := handler.chunks[1]; len(chunk) > extraSize {
+	if chunk := h.chunks[1]; len(chunk) > extraSize {
 		t.Errorf("expected at most %d bytes, got %d", extraSize, len(chunk))
 	}
 	expectedLogs := []string{"DONE"}
@@ -383,18 +301,18 @@ func TestRunSkipped(t *testing.T) {
 	t.Parallel()
 
 	lastRun := time.Date(2021, 10, 12, 10, 30, 38, 0, time.Local)
-	handler := &testHandler{lastRun: lastRun}
+	h := &testHandler{lastRun: lastRun}
 	schedule, err := utils.NewSchedule("0,30 * * * *")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	dest := handler.Destination{}
+	dest.SetSchedule(*schedule).SetHandler(h)
 	logger, lines := newTestLogger()
 	task := &Task{
-		command: []string{"echo", "hello world"},
-		destinations: []destination{
-			{handler: handler, schedule: *schedule},
-		},
-		logger: logger,
+		command:      []string{"echo", "hello world"},
+		destinations: handler.Destinations{dest},
+		logger:       logger,
 	}
 
 	now := time.Date(2021, 10, 12, 10, 59, 38, 0, time.Local)
@@ -402,8 +320,8 @@ func TestRunSkipped(t *testing.T) {
 		t.Errorf("unexpected result: %+v", res)
 	}
 
-	if len(handler.chunks) != 0 {
-		t.Errorf("expected 0 chunks, got %d", len(handler.chunks))
+	if len(h.chunks) != 0 {
+		t.Errorf("expected 0 chunks, got %d", len(h.chunks))
 	}
 
 	expectedLogs := []string{"SKIPPED"}
@@ -416,14 +334,14 @@ func TestRunHandlerInitError(t *testing.T) {
 	t.Parallel()
 
 	initErr := errors.New("handler could not be initialized: init error")
-	handler := &testHandler{initErr: initErr}
+	h := &testHandler{initErr: initErr}
+	dest := handler.Destination{}
+	dest.SetHandler(h)
 	logger, lines := newTestLogger()
 	task := &Task{
-		command: []string{"echo", "hello world"},
-		destinations: []destination{
-			{handler: handler},
-		},
-		logger: logger,
+		command:      []string{"echo", "hello world"},
+		destinations: handler.Destinations{dest},
+		logger:       logger,
 	}
 
 	if res := task.Run(time.Now()); res.Status() != StatusFailed {
@@ -432,8 +350,8 @@ func TestRunHandlerInitError(t *testing.T) {
 		t.Errorf("expected %v, got %v", initErr, res.Error())
 	}
 
-	if len(handler.chunks) != 0 {
-		t.Errorf("expected 0 chunks, got %d", len(handler.chunks))
+	if len(h.chunks) != 0 {
+		t.Errorf("expected 0 chunks, got %d", len(h.chunks))
 	}
 
 	expectedLogs := []string{"ERROR (Initialization failed): handler could not be initialized: init error"}
@@ -446,27 +364,27 @@ func TestRunLastRunError(t *testing.T) {
 	t.Parallel()
 
 	lastRunErr := errors.New("last run error")
-	handler := &testHandler{lastRunErr: lastRunErr}
+	h := &testHandler{lastRunErr: lastRunErr}
+	dest := handler.Destination{}
+	dest.SetHandler(h)
 	logger, lines := newTestLogger()
 	task := &Task{
-		command: []string{"echo", "hello world"},
-		destinations: []destination{
-			{handler: handler},
-		},
-		logger: logger,
+		command:      []string{"echo", "hello world"},
+		destinations: handler.Destinations{dest},
+		logger:       logger,
 	}
 
 	if res := task.Run(time.Now()); res.Status() != StatusFailed {
 		t.Errorf("unexpected result: %+v", res)
-	} else if res.Error() != lastRunErr {
+	} else if !errors.Is(res.Error(), lastRunErr) {
 		t.Errorf("expected %v, got %v", lastRunErr, res.Error())
 	}
 
-	if len(handler.chunks) != 0 {
-		t.Errorf("expected 0 chunks, got %d", len(handler.chunks))
+	if len(h.chunks) != 0 {
+		t.Errorf("expected 0 chunks, got %d", len(h.chunks))
 	}
 
-	expectedLogs := []string{"ERROR (Could not find last run): last run error"}
+	expectedLogs := []string{"ERROR (Could not find last run): 1 error occurred:", "\t* last run error", ""}
 	if logs := lines(); !reflect.DeepEqual(logs, expectedLogs) {
 		t.Errorf("expected %q, got %q", expectedLogs, logs)
 	}
@@ -547,13 +465,10 @@ func TestTaskRunner(t *testing.T) {
 			task := &Task{
 				command: tc.command,
 				timeout: 30 * time.Millisecond,
-				destinations: []destination{
-					{handler: tc.handler},
-				},
-				logger: logger,
+				logger:  logger,
 			}
 
-			result := task.runner(time.Now())
+			result := task.runner(time.Now(), []handler.Handler{tc.handler})
 			if result.Status() != tc.status {
 				t.Errorf("expected status %+v, got %+v", tc.status, result.Status())
 			}

--- a/backup/tasks_list_test.go
+++ b/backup/tasks_list_test.go
@@ -63,14 +63,15 @@ func TestNewTasksList(t *testing.T) {
 		"foo": {
 			Command: []string{"echo", "foo bar"},
 			Env:     []string{"FOO=bar"},
-			Destination: []config.Destination{
+			Destinations: []config.Destination{
 				{Type: "s3"},
 			},
 		},
 		"bar": {
 			Command: []string{"echo", "bar foo"},
 			Env:     []string{"BAR=foo"},
-			Destination: []config.Destination{
+			Destinations: []config.Destination{
+				{Type: "s3"},
 				{Type: "s3"},
 			},
 		},
@@ -103,11 +104,6 @@ func TestNewTasksList(t *testing.T) {
 			if len(task.destinations) != 1 {
 				t.Errorf("expected 1 destination, got %d", len(task.destinations))
 			}
-			for _, dest := range task.destinations {
-				if _, ok := dest.handler.(*handler.S3Handler); !ok {
-					t.Errorf("expected S3Handler, got %T", dest.handler)
-				}
-			}
 			if task.logger.Prefix() != "[foo] " {
 				t.Errorf("expected log prefix '[foo] ', got %s", task.logger.Prefix())
 			}
@@ -118,13 +114,8 @@ func TestNewTasksList(t *testing.T) {
 			if !reflect.DeepEqual(task.env, []string{"BAR=foo"}) {
 				t.Errorf("expected task env 'BAR=foo', got %v", task.env)
 			}
-			if len(task.destinations) != 1 {
+			if len(task.destinations) != 2 {
 				t.Errorf("expected 1 destination, got %d", len(task.destinations))
-			}
-			for _, dest := range task.destinations {
-				if _, ok := dest.handler.(*handler.S3Handler); !ok {
-					t.Errorf("expected S3Handler, got %T", dest.handler)
-				}
 			}
 			if task.logger.Prefix() != "[bar] " {
 				t.Errorf("expected log prefix '[bar] ', got %s", task.logger.Prefix())
@@ -145,7 +136,7 @@ func TestNewTasksListError(t *testing.T) {
 		"foo": {
 			Command: []string{"echo", "foo bar"},
 			Env:     []string{"FOO=bar"},
-			Destination: []config.Destination{
+			Destinations: []config.Destination{
 				{Type: "s3"},
 			},
 		},

--- a/backup/tasks_list_test.go
+++ b/backup/tasks_list_test.go
@@ -63,15 +63,15 @@ func TestNewTasksList(t *testing.T) {
 		"foo": {
 			Command: []string{"echo", "foo bar"},
 			Env:     []string{"FOO=bar"},
-			Destination: config.Destination{
-				Type: "s3",
+			Destination: []config.Destination{
+				{Type: "s3"},
 			},
 		},
 		"bar": {
 			Command: []string{"echo", "bar foo"},
 			Env:     []string{"BAR=foo"},
-			Destination: config.Destination{
-				Type: "s3",
+			Destination: []config.Destination{
+				{Type: "s3"},
 			},
 		},
 	}
@@ -100,8 +100,13 @@ func TestNewTasksList(t *testing.T) {
 			if !reflect.DeepEqual(task.env, []string{"FOO=bar"}) {
 				t.Errorf("expected task env 'FOO=bar', got %v", task.env)
 			}
-			if _, ok := task.handler.(*handler.S3Handler); !ok {
-				t.Errorf("expected S3Handler, got %T", task.handler)
+			if len(task.destinations) != 1 {
+				t.Errorf("expected 1 destination, got %d", len(task.destinations))
+			}
+			for _, dest := range task.destinations {
+				if _, ok := dest.handler.(*handler.S3Handler); !ok {
+					t.Errorf("expected S3Handler, got %T", dest.handler)
+				}
 			}
 			if task.logger.Prefix() != "[foo] " {
 				t.Errorf("expected log prefix '[foo] ', got %s", task.logger.Prefix())
@@ -113,8 +118,13 @@ func TestNewTasksList(t *testing.T) {
 			if !reflect.DeepEqual(task.env, []string{"BAR=foo"}) {
 				t.Errorf("expected task env 'BAR=foo', got %v", task.env)
 			}
-			if _, ok := task.handler.(*handler.S3Handler); !ok {
-				t.Errorf("expected S3Handler, got %T", task.handler)
+			if len(task.destinations) != 1 {
+				t.Errorf("expected 1 destination, got %d", len(task.destinations))
+			}
+			for _, dest := range task.destinations {
+				if _, ok := dest.handler.(*handler.S3Handler); !ok {
+					t.Errorf("expected S3Handler, got %T", dest.handler)
+				}
 			}
 			if task.logger.Prefix() != "[bar] " {
 				t.Errorf("expected log prefix '[bar] ', got %s", task.logger.Prefix())
@@ -135,8 +145,8 @@ func TestNewTasksListError(t *testing.T) {
 		"foo": {
 			Command: []string{"echo", "foo bar"},
 			Env:     []string{"FOO=bar"},
-			Destination: config.Destination{
-				Type: "s3",
+			Destination: []config.Destination{
+				{Type: "s3"},
 			},
 		},
 		"bar": {

--- a/config/destination.go
+++ b/config/destination.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/chialab/streamlined-backup/utils"
 )
 
 const S3_TIME_FORMAT = "20060102150405"
@@ -21,8 +22,9 @@ const (
 )
 
 type Destination struct {
-	Type DestinationType         `json:"type" toml:"type"`
-	S3   S3DestinationDefinition `json:"s3" toml:"s3"`
+	Type     DestinationType          `json:"type" toml:"type"`
+	Schedule utils.ScheduleExpression `json:"schedule" toml:"schedule"`
+	S3       S3DestinationDefinition  `json:"s3" toml:"s3"`
 }
 
 type S3DestinationDefinition struct {

--- a/config/main.go
+++ b/config/main.go
@@ -12,11 +12,11 @@ import (
 var ErrUnsupportedConfigFile = errors.New("unsupported config file")
 
 type Task struct {
-	Command     []string      `json:"command" toml:"command"`
-	Cwd         string        `json:"cwd" toml:"cwd"`
-	Env         []string      `json:"env" toml:"env"`
-	Timeout     string        `json:"timeout" toml:"timeout"`
-	Destination []Destination `json:"destinations" toml:"destination"`
+	Command      []string      `json:"command" toml:"command"`
+	Cwd          string        `json:"cwd" toml:"cwd"`
+	Env          []string      `json:"env" toml:"env"`
+	Timeout      string        `json:"timeout" toml:"timeout"`
+	Destinations []Destination `json:"destinations" toml:"destination"`
 }
 
 func LoadConfiguration(path string) (map[string]Task, error) {

--- a/config/main.go
+++ b/config/main.go
@@ -7,18 +7,16 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/chialab/streamlined-backup/utils"
 )
 
 var ErrUnsupportedConfigFile = errors.New("unsupported config file")
 
 type Task struct {
-	Schedule    utils.ScheduleExpression `json:"schedule" toml:"schedule"`
-	Command     []string                 `json:"command" toml:"command"`
-	Cwd         string                   `json:"cwd" toml:"cwd"`
-	Env         []string                 `json:"env" toml:"env"`
-	Timeout     string                   `json:"timeout" toml:"timeout"`
-	Destination Destination              `json:"destination" toml:"destination"`
+	Command     []string      `json:"command" toml:"command"`
+	Cwd         string        `json:"cwd" toml:"cwd"`
+	Env         []string      `json:"env" toml:"env"`
+	Timeout     string        `json:"timeout" toml:"timeout"`
+	Destination []Destination `json:"destinations" toml:"destination"`
 }
 
 func LoadConfiguration(path string) (map[string]Task, error) {

--- a/config/main_test.go
+++ b/config/main_test.go
@@ -56,7 +56,7 @@ command = ["tar", "-cvjf-", "/path/to/files"]
 	expected := map[string]Task{
 		"backup_mysql_database": {
 			Command: []string{"/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=0 --set-gtid-purged=off my_database | bzip2"},
-			Destination: []Destination{
+			Destinations: []Destination{
 				Destination{
 					Type:     S3Destination,
 					Schedule: *schedule,
@@ -72,7 +72,7 @@ command = ["tar", "-cvjf-", "/path/to/files"]
 		},
 		"my_tar_archive": {
 			Command: []string{"tar", "-cvjf-", "/path/to/files"},
-			Destination: []Destination{
+			Destinations: []Destination{
 				Destination{
 					Type:     S3Destination,
 					Schedule: *schedule,
@@ -175,7 +175,7 @@ func TestLoadConfigurationJson(t *testing.T) {
 	expected := map[string]Task{
 		"backup_mysql_database": {
 			Command: []string{"/bin/sh", "-c", "mysqldump --single-transaction --column-statistics=0 --set-gtid-purged=off my_database | bzip2"},
-			Destination: []Destination{
+			Destinations: []Destination{
 				Destination{
 					Type:     S3Destination,
 					Schedule: *schedule,
@@ -191,7 +191,7 @@ func TestLoadConfigurationJson(t *testing.T) {
 		},
 		"my_tar_archive": {
 			Command: []string{"tar", "-cvjf-", "/path/to/files"},
-			Destination: []Destination{
+			Destinations: []Destination{
 				Destination{
 					Type:     S3Destination,
 					Schedule: *schedule,

--- a/handler/destination.go
+++ b/handler/destination.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"sync"
+	"time"
+
+	"github.com/chialab/streamlined-backup/config"
+	"github.com/chialab/streamlined-backup/utils"
+	"github.com/hashicorp/go-multierror"
+)
+
+func NewDestination(destination config.Destination) (Destination, error) {
+	if handler, err := NewHandler(destination); err != nil {
+		return Destination{}, err
+	} else {
+		return Destination{
+			schedule: destination.Schedule,
+			handler:  handler,
+		}, nil
+	}
+}
+
+type Destination struct {
+	schedule utils.ScheduleExpression
+	handler  Handler
+}
+
+func (d *Destination) SetSchedule(schedule utils.ScheduleExpression) *Destination {
+	d.schedule = schedule
+
+	return d
+}
+
+func (d *Destination) SetHandler(handler Handler) *Destination {
+	d.handler = handler
+
+	return d
+}
+
+func (d Destination) ShouldRun(now time.Time) (bool, error) {
+	lastRun, err := d.handler.LastRun()
+	if err != nil {
+		return false, err
+	}
+
+	if lastRun.IsZero() {
+		return true, nil
+	}
+
+	return d.schedule.Next(lastRun).Before(now), nil
+}
+
+type Destinations []Destination
+
+func (d Destinations) GetHandlers(now time.Time) ([]Handler, error) {
+	var merr *multierror.Error
+	filtered := []Handler{}
+	mutex := &sync.Mutex{}
+	wg := &sync.WaitGroup{}
+
+	for _, dest := range d {
+		wg.Add(1)
+		go func(dest Destination) {
+			defer wg.Done()
+			shouldRun, err := dest.ShouldRun(now)
+
+			mutex.Lock()
+			defer mutex.Unlock()
+			if err != nil {
+				merr = multierror.Append(merr, err)
+			} else if shouldRun {
+				filtered = append(filtered, dest.handler)
+			}
+		}(dest)
+	}
+
+	wg.Wait()
+	if merr != nil {
+		return nil, merr
+	}
+
+	return filtered, nil
+}

--- a/handler/destination_test.go
+++ b/handler/destination_test.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chialab/streamlined-backup/utils"
+)
+
+type testHandler struct {
+	lastRun    time.Time
+	lastRunErr error
+}
+
+func (r *testHandler) LastRun() (time.Time, error) {
+	return r.lastRun, r.lastRunErr
+}
+
+func (r testHandler) Handler(*io.PipeReader, time.Time) (func() error, error) {
+	panic("unepected call")
+}
+
+func TestDestinationShouldRun(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		expected bool
+		lastRun  time.Time
+		schedule string
+	}
+	cases := map[string]testCase{
+		"yes": {
+			expected: true,
+			lastRun:  time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local),
+			schedule: "0 10 * * *",
+		},
+		"no": {
+			expected: false,
+			lastRun:  time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local),
+			schedule: "@weekly",
+		},
+		"never_run": {
+			expected: true,
+			lastRun:  time.Time{},
+			schedule: "@weekly",
+		},
+	}
+	now := time.Date(2021, 10, 6, 19, 10, 38, 0, time.Local)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var (
+				schedule *utils.ScheduleExpression
+				err      error
+			)
+			if schedule, err = utils.NewSchedule(tc.schedule); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			handler := &testHandler{lastRun: tc.lastRun}
+			destination := &Destination{
+				schedule: *schedule,
+				handler:  handler,
+			}
+
+			if result, err := destination.ShouldRun(now); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			} else if result != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestDestinationShouldRunError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		schedule *utils.ScheduleExpression
+		err      error
+	)
+	if schedule, err = utils.NewSchedule("@daily"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	testErr := errors.New("test error")
+	handler := &testHandler{lastRunErr: testErr}
+	destination := &Destination{
+		schedule: *schedule,
+		handler:  handler,
+	}
+
+	now := time.Date(2021, 10, 6, 19, 10, 38, 0, time.Local)
+	if result, err := destination.ShouldRun(now); result != false {
+		t.Errorf("unexpected result: %t", result)
+	} else if err != testErr {
+		t.Errorf("expected %v, got %v", testErr, err)
+	}
+}
+
+func TestDestinationsGetHandlers(t *testing.T) {
+	t.Parallel()
+
+	config := []struct {
+		schedule string
+		lastRun  time.Time
+	}{
+		{schedule: "0 10 * * *", lastRun: time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local)},
+		{schedule: "@weekly", lastRun: time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local)},
+		{schedule: "@weekly", lastRun: time.Time{}},
+	}
+
+	destinations := make(Destinations, 3)
+	for i, tc := range config {
+		if schedule, err := utils.NewSchedule(tc.schedule); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		} else {
+			handler := &testHandler{lastRun: tc.lastRun}
+			destinations[i] = Destination{
+				schedule: *schedule,
+				handler:  handler,
+			}
+		}
+	}
+
+	now := time.Date(2021, 10, 6, 19, 10, 38, 0, time.Local)
+	if result, err := destinations.GetHandlers(now); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(result) != 2 {
+		t.Errorf("expected 2 destinations, got %d", len(result))
+	} else if !reflect.DeepEqual(result, []Handler{destinations[0].handler, destinations[2].handler}) && !reflect.DeepEqual(result, []Handler{destinations[2].handler, destinations[0].handler}) {
+		t.Errorf("expected %#v, got %#v", []Handler{destinations[0].handler, destinations[2].handler}, result)
+	}
+}
+
+func TestDestinationsGetHandlersErrors(t *testing.T) {
+	t.Parallel()
+
+	config := []struct {
+		schedule string
+		lastRun  time.Time
+	}{
+		{schedule: "0 10 * * *", lastRun: time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local)},
+		{schedule: "@weekly", lastRun: time.Date(2021, 10, 3, 19, 10, 38, 0, time.Local)},
+		{schedule: "@weekly", lastRun: time.Time{}},
+	}
+
+	destinations := make(Destinations, 3)
+	for i, tc := range config {
+		if schedule, err := utils.NewSchedule(tc.schedule); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		} else {
+			handler := &testHandler{lastRun: tc.lastRun}
+			destinations[i] = Destination{
+				schedule: *schedule,
+				handler:  handler,
+			}
+		}
+	}
+
+	now := time.Date(2021, 10, 6, 19, 10, 38, 0, time.Local)
+	if result, err := destinations.GetHandlers(now); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(result) != 2 {
+		t.Errorf("expected 2 destinations, got %d", len(result))
+	} else if !reflect.DeepEqual(result, []Handler{destinations[0].handler, destinations[2].handler}) && !reflect.DeepEqual(result, []Handler{destinations[2].handler, destinations[0].handler}) {
+		t.Errorf("expected %#v, got %#v", []Handler{destinations[0].handler, destinations[2].handler}, result)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -198,7 +198,7 @@ func TestRunInvalidConfig(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	configFile := path.Join(tmpDir, "foo.json")
-	data := `{"foo": {"timeout": "5s", "destination": {"type": "unknown"}}}`
+	data := `{"foo": {"timeout": "5s", "destinations": [{"type": "unknown"}]}}`
 	if err := os.WriteFile(configFile, []byte(data), 0644); err != nil {
 		t.Fatalf("unepected error: %s", err)
 	}
@@ -222,7 +222,7 @@ func TestRunPidRunning(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	configFile := path.Join(tmpDir, "foo.json")
-	data := `{"foo": {"destination": {"type": "s3"}}}`
+	data := `{"foo": {"destinations": [{"type": "s3"}]}}`
 	if err := os.WriteFile(configFile, []byte(data), 0644); err != nil {
 		t.Fatalf("unepected error: %s", err)
 	}

--- a/notifier/slack_test.go
+++ b/notifier/slack_test.go
@@ -19,11 +19,11 @@ func TestSlackFormat(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	taskFoo, err := backup.NewTask("foo", config.Task{Destination: []config.Destination{{Type: config.S3Destination}}})
+	taskFoo, err := backup.NewTask("foo", config.Task{Destinations: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	taskBar, err := backup.NewTask("bar", config.Task{Command: []string{"echo", "foo bar"}, Cwd: tmpDir, Destination: []config.Destination{{Type: config.S3Destination}}})
+	taskBar, err := backup.NewTask("bar", config.Task{Command: []string{"echo", "foo bar"}, Cwd: tmpDir, Destinations: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestSlackFormat(t *testing.T) {
 func TestSlackNotify(t *testing.T) {
 	t.Parallel()
 
-	task, err := backup.NewTask("foo", config.Task{Destination: []config.Destination{{Type: config.S3Destination}}})
+	task, err := backup.NewTask("foo", config.Task{Destinations: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestSlackNotifyEmpty(t *testing.T) {
 func TestSlackNotifyError(t *testing.T) {
 	t.Parallel()
 
-	task, err := backup.NewTask("foo", config.Task{Destination: []config.Destination{{Type: config.S3Destination}}})
+	task, err := backup.NewTask("foo", config.Task{Destinations: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/notifier/slack_test.go
+++ b/notifier/slack_test.go
@@ -19,11 +19,11 @@ func TestSlackFormat(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	taskFoo, err := backup.NewTask("foo", config.Task{Destination: config.Destination{Type: config.S3Destination}})
+	taskFoo, err := backup.NewTask("foo", config.Task{Destination: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	taskBar, err := backup.NewTask("bar", config.Task{Command: []string{"echo", "foo bar"}, Cwd: tmpDir, Destination: config.Destination{Type: config.S3Destination}})
+	taskBar, err := backup.NewTask("bar", config.Task{Command: []string{"echo", "foo bar"}, Cwd: tmpDir, Destination: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestSlackFormat(t *testing.T) {
 func TestSlackNotify(t *testing.T) {
 	t.Parallel()
 
-	task, err := backup.NewTask("foo", config.Task{Destination: config.Destination{Type: config.S3Destination}})
+	task, err := backup.NewTask("foo", config.Task{Destination: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestSlackNotifyEmpty(t *testing.T) {
 func TestSlackNotifyError(t *testing.T) {
 	t.Parallel()
 
-	task, err := backup.NewTask("foo", config.Task{Destination: config.Destination{Type: config.S3Destination}})
+	task, err := backup.NewTask("foo", config.Task{Destination: []config.Destination{{Type: config.S3Destination}}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/multi_pipe_writer.go
+++ b/utils/multi_pipe_writer.go
@@ -1,0 +1,40 @@
+package utils
+
+import "io"
+
+type WriteCloserWithError interface {
+	io.WriteCloser
+	CloseWithError(error) error
+}
+
+type multiPipeWriter struct {
+	writers []*io.PipeWriter
+}
+
+func (w *multiPipeWriter) Write(p []byte) (int, error) {
+	for _, writer := range w.writers {
+		if n, err := writer.Write(p); err != nil {
+			return n, err
+		}
+	}
+
+	return len(p), nil
+}
+
+func (w *multiPipeWriter) Close() error {
+	return w.CloseWithError(nil)
+}
+
+func (w *multiPipeWriter) CloseWithError(err error) error {
+	for _, writer := range w.writers {
+		if e := writer.CloseWithError(err); e != nil {
+			return e
+		}
+	}
+
+	return nil
+}
+
+func MultiPipeWriter(writers ...*io.PipeWriter) WriteCloserWithError {
+	return &multiPipeWriter{writers}
+}

--- a/utils/multi_pipe_writer_test.go
+++ b/utils/multi_pipe_writer_test.go
@@ -1,0 +1,188 @@
+package utils
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestMultiPipeWriter(t *testing.T) {
+	wg := sync.WaitGroup{}
+	writers := []*io.PipeWriter{}
+
+	for i := 0; i < 10; i++ {
+		r, w := io.Pipe()
+		writers = append(writers, w)
+
+		wg.Add(1)
+		go func(r *io.PipeReader) {
+			defer wg.Done()
+
+			buf := make([]byte, 1024)
+			if n, err := r.Read(buf); err != nil {
+				t.Errorf("read failed: %#v", err)
+			} else if n != 5 {
+				t.Errorf("read returned %d bytes, expected 5", n)
+			} else if string(buf[:n]) != "hello" {
+				t.Errorf("read returned %s, expected hello", string(buf[:n]))
+			}
+
+			if n, err := r.Read(buf); err != io.EOF {
+				t.Errorf("read failed: expected %#v, got %#v", io.EOF, err)
+			} else if n != 0 {
+				t.Errorf("read returned %d bytes, expected 0", n)
+			}
+
+			if err := r.Close(); err != nil {
+				t.Errorf("close failed: %#v", err)
+			}
+		}(r)
+	}
+
+	mw := MultiPipeWriter(writers...)
+	if n, err := mw.Write([]byte("hello")); err != nil {
+		t.Errorf("write failed: %#v", err)
+	} else if n != 5 {
+		t.Errorf("write returned %d bytes, expected 5", n)
+	}
+
+	if err := mw.Close(); err != nil {
+		t.Errorf("close failed: %#v", err)
+	}
+
+	wg.Wait()
+}
+
+func TestMultiPipeWriterClose(t *testing.T) {
+	wg := sync.WaitGroup{}
+	writers := []*io.PipeWriter{}
+
+	testErr := errors.New("test error")
+
+	for i := 0; i < 2; i++ {
+		r, w := io.Pipe()
+		writers = append(writers, w)
+
+		wg.Add(1)
+		go func(r *io.PipeReader) {
+			defer wg.Done()
+
+			buf := make([]byte, 1024)
+			if n, err := r.Read(buf); err != nil {
+				t.Errorf("read failed: %#v", err)
+			} else if n != 5 {
+				t.Errorf("read returned %d bytes, expected 5", n)
+			} else if string(buf[:n]) != "hello" {
+				t.Errorf("read returned %s, expected hello", string(buf[:n]))
+			}
+
+			if n, err := r.Read(buf); err != testErr {
+				t.Errorf("read failed: expected %#v, got %#v", testErr, err)
+			} else if n != 0 {
+				t.Errorf("read returned %d bytes, expected 0", n)
+			}
+
+			if err := r.Close(); err != nil {
+				t.Errorf("close failed: %#v", err)
+			}
+		}(r)
+	}
+
+	mw := MultiPipeWriter(writers...)
+	if n, err := mw.Write([]byte("hello")); err != nil {
+		t.Errorf("write failed: %#v", err)
+	} else if n != 5 {
+		t.Errorf("write returned %d bytes, expected 5", n)
+	}
+
+	if err := mw.CloseWithError(testErr); err != nil {
+		t.Errorf("close failed: %#v", err)
+	}
+
+	wg.Wait()
+}
+
+func TestMultiPipeWriterReaderClose(t *testing.T) {
+	wg := sync.WaitGroup{}
+	writers := []*io.PipeWriter{}
+	wait := make(chan bool)
+
+	testErr := errors.New("test error")
+
+	for i := 0; i < 3; i++ {
+		r, w := io.Pipe()
+		writers = append(writers, w)
+
+		wg.Add(1)
+		go func(r *io.PipeReader, i int) {
+			defer wg.Done()
+
+			buf := make([]byte, 1024)
+			if n, err := r.Read(buf); err != nil {
+				t.Errorf("read failed: %#v", err)
+			} else if n != 5 {
+				t.Errorf("read returned %d bytes, expected 5", n)
+			} else if string(buf[:n]) != "hello" {
+				t.Errorf("read returned %s, expected hello", string(buf[:n]))
+			}
+
+			switch i {
+			case 0:
+				if n, err := r.Read(buf); err != nil {
+					t.Errorf("read failed: %#v", err)
+				} else if n != 5 {
+					t.Errorf("read returned %d bytes, expected 5", n)
+				} else if string(buf[:n]) != "world" {
+					t.Errorf("read returned %s, expected world", string(buf[:n]))
+				}
+
+				if n, err := r.Read(buf); err != testErr {
+					t.Errorf("read failed: expected %#v, got %#v", testErr, err)
+				} else if n != 0 {
+					t.Errorf("read returned %d bytes, expected 0", n)
+
+				}
+
+				if err := r.Close(); err != nil {
+					t.Errorf("close failed: %#v", err)
+				}
+			case 1:
+				if err := r.CloseWithError(testErr); err != nil {
+					t.Errorf("close failed: %#v", err)
+				}
+				wait <- true
+			case 2:
+				if n, err := r.Read(buf); err != testErr {
+					t.Errorf("read failed: expected %#v, got %#v", testErr, err)
+				} else if n != 0 {
+					t.Errorf("read returned %d bytes, expected 0", n)
+
+				}
+
+				if err := r.Close(); err != nil {
+					t.Errorf("close failed: %#v", err)
+				}
+			}
+		}(r, i)
+	}
+
+	mw := MultiPipeWriter(writers...)
+	if n, err := mw.Write([]byte("hello")); err != nil {
+		t.Errorf("write failed: %#v", err)
+	} else if n != 5 {
+		t.Errorf("write returned %d bytes, expected 5", n)
+	}
+	<-wait
+	if n, err := mw.Write([]byte("world")); err != testErr {
+		t.Errorf("write failed: expected %#v, got %#v", testErr, err)
+	} else if n != 0 {
+		t.Errorf("write returned %d bytes, expected 0", n)
+	}
+
+	if err := mw.CloseWithError(testErr); err != nil {
+		t.Errorf("close failed: %#v", err)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
This PR attempts to resolve #6 and introduce the support for multiple destinations, each with its own schedule, for every task.

The task command will be executed if, and only if, at least one destination's schedule is due for executing. If so, the command will be executed once, and its output will be written to all the destinations that need an updated backup.